### PR TITLE
Fix Workflow DevKit typo in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -259,7 +259,7 @@ This template is built on top of Workflow DevKit, a powerful workflow execution 
 - Built-in logging and error handling
 - Serverless deployment support
 
-Learn more about Workflow DevKit at [workflow.dev](https://workflow.dev)
+Learn more about Workflow DevKit at [workflow.dev](https://useworkflow.dev)
 
 ## License
 


### PR DESCRIPTION
The link for Workflow Devkit is broken. This updates the URL to https://useworkflow.dev