### PR TITLE
feat(ai-elements): prompt input style

### DIFF
--- a/components/ai-elements/prompt.tsx
+++ b/components/ai-elements/prompt.tsx
@@ -326,8 +326,13 @@ export function AIPrompt({ workflowId, onWorkflowCreated }: AIPromptProps) {
           <div className="relative size-8 shrink-0 self-end">
             <Button
               aria-label="Focus prompt input (⌘K)"
-              className="absolute w-fit inset-0 h-8 px-0 text-xs text-muted-foreground hover:bg-transparent transition-[opacity,filter] ease-out"
+              className="absolute inset-0 h-8 px-0 text-xs text-muted-foreground hover:bg-transparent transition-[opacity,filter] ease-out"
               onClick={() => inputRef.current?.focus()}
+              style={
+                !prompt.trim() && !isGenerating && !isFocused
+                  ? { opacity: 1, filter: "blur(0px)", pointerEvents: "auto", visibility: "visible" }
+                  : { opacity: 0, filter: "blur(2px)", pointerEvents: "none", visibility: "hidden" }
+              }
               type="button"
               variant="ghost"
             >


### PR DESCRIPTION
**description**
this pr is a nitpick proposal to enhance the prompt input style in order to:
- fix prompt input lint style
- align bottom submit button on multi line text
- maintain height consistency on unfocus/focus
- enhance animation between `kbd` and button

`unfocus`
| state | preview |
| -------|------|
| before | <img width="600" height="86" alt="image" src="https://github.com/user-attachments/assets/bfe4c699-333f-4ca1-9d4b-7b500b6a1023" /> |
| after | <img width="600" height="86" alt="image" src="https://github.com/user-attachments/assets/6f11b3ad-d307-4004-8a16-2e26b092bfb9" /> | 

`multiline`
| state | preview |
| -------|------|
| before | <img width="600" height="114" alt="image" src="https://github.com/user-attachments/assets/9dfdc702-684d-48df-a10d-83610ec840de" /> |
| after | <img width="600" height="114" alt="image" src="https://github.com/user-attachments/assets/e9c85ef2-0739-4a5e-8a7a-d4a9a088c6b2" /> | 

thank you for bringing that oss gem!