### PR TITLE
Fix environment file loading in drizzle configuration

### DIFF
--- a/drizzle.config.ts
+++ b/drizzle.config.ts
@@ -2,7 +2,7 @@ import { config } from "dotenv";
 import type { Config } from "drizzle-kit";
 
 config({ path: ".env" });
-config({ path: ".env.local" });
+config({ path: ".env.local", override: true });
 
 export default {
   schema: "./lib/db/schema.ts",


### PR DESCRIPTION
## Problem

The drizzle configuration was using `config()` from dotenv without specifying a path, which caused inconsistent loading of `.env.local` files in the drizzle-kit execution context. This resulted in `DATABASE_URL` being undefined, causing drizzle-kit to fall back to the default database connection (`postgres://localhost:5432/workflow`) instead of loading the correct database URL from `.env.local`.

## Solution
Updated `drizzle.config.ts` to explicitly load both `.env` and `.env.local` files:
- `.env` loads first with base configuration
- `.env.local` loads second and can override values

## Testing
- `pnpm db:push` now correctly loads environment variables from `.env.local`
- No more fallback to the default database connection