### PR TITLE
Fix sidebar toggle UI logic (close button visibility)

### DIFF
--- a/app/workflows/[workflowId]/page.tsx
+++ b/app/workflows/[workflowId]/page.tsx
@@ -711,7 +711,7 @@ const WorkflowEditor = ({ params }: WorkflowPageProps) => {
             {/* Hover indicator */}
             <div className="absolute inset-y-0 left-0 w-1 bg-transparent transition-colors group-hover:bg-blue-500 group-active:bg-blue-600" />
             {/* Collapse button - hidden while resizing */}
-            {!isDraggingResize && (
+            {!isDraggingResize && !panelCollapsed && (
               <button
                 className="-translate-x-1/2 -translate-y-1/2 absolute top-1/2 left-0 flex size-6 items-center justify-center rounded-full border bg-background opacity-0 shadow-sm transition-opacity hover:bg-muted group-hover:opacity-100"
                 onClick={(e) => {


### PR DESCRIPTION
The close button was rendering on hover even when the sidebar was closed.
Updated the condition so the close button only appears when the sidebar is open.

<img width="1919" height="990" alt="Screenshot 2025-11-28 015335" src="https://github.com/user-attachments/assets/d9e75a43-6ede-442c-b970-4dde25222174" />
<img width="339" height="594" alt="Screenshot 2025-11-28 015350" src="https://github.com/user-attachments/assets/f97497b0-5bb7-434d-b2f9-207cd6afe9d7" />

This corrects the toggle behavior and prevents both icons from appearing simultaneously.