### PR TITLE
DOCS: Update README script references to match package.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,10 +171,10 @@ pnpm build
 pnpm type-check
 
 # Linting
-pnpm lint
+pnpm check
 
 # Formatting
-pnpm format
+pnpm fix
 
 # Database
 pnpm db:generate  # Generate migrations


### PR DESCRIPTION
The README referenced non-existent npm scripts:
- `pnpm lint` (doesn't exist)
- `pnpm format` (doesn't exist)


Updated README.md to reference the actual available scripts:
- `pnpm lint` → `pnpm check` (Ultracite linting)
- `pnpm format` → `pnpm fix` (Ultracite formatting + auto-fixes)