### PR TITLE
fix: include a `.env.example` file, add clarification around required environment variables (fixes #74)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,25 @@
+## Database
+DATABASE_URL=postgresql://user:password@localhost:5432/workflow_builder
+
+## Better Auth
+BETTER_AUTH_SECRET=your-secret-key # Generate with: openssl rand -base64 32
+BETTER_AUTH_URL=http://localhost:3000
+
+# GitHub
+GITHUB_CLIENT_ID=
+GITHUB_CLIENT_SECRET=
+NEXT_PUBLIC_GITHUB_CLIENT_ID=
+
+# Google
+GOOGLE_CLIENT_ID=
+GOOGLE_CLIENT_SECRET=
+NEXT_PUBLIC_GOOGLE_CLIENT_ID=
+
+## AI Gateway (for AI workflow generation)
+AI_GATEWAY_API_KEY=your-openai-api-key
+
+## API URL (for application Route Handlers)
+NEXT_PUBLIC_API_URL=http://localhost:3000
+
+## Credentials Encryption
+INTEGRATION_ENCRYPTION_KEY=your-32-byte-hexadecimal-key # Generate with: openssl rand -hex 32

--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,7 @@ yarn-error.log*
 
 # env files (can opt-in for committing if needed)
 .env*
+!.env.example
 
 # vercel
 .vercel
@@ -40,6 +41,5 @@ yarn-error.log*
 # typescript
 *.tsbuildinfo
 next-env.d.ts
-.env*.local
 
 tmp/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -68,16 +68,20 @@ Required variables for development:
 
 ```bash
 # Database
-DATABASE_URL=postgres://localhost:5432/workflow
+DATABASE_URL=postgresql://user:password@localhost:5432/workflow_builder
 
-# Authentication
-BETTER_AUTH_SECRET=your-auth-secret-here  # Generate with: openssl rand -base64 32
+# Better Auth
+BETTER_AUTH_SECRET=your-secret-key # Generate with: openssl rand -base64 32
+BETTER_AUTH_URL=http://localhost:3000
+
+# AI Gateway (for AI workflow generation)
+AI_GATEWAY_API_KEY=your-openai-api-key
+
+# API URL (for application Route Handlers)
+NEXT_PUBLIC_API_URL=http://localhost:3000
 
 # Credentials Encryption
-INTEGRATION_ENCRYPTION_KEY=your-64-character-hex-string  # Generate with: openssl rand -hex 32
-
-# App URLs
-NEXT_PUBLIC_APP_URL=http://localhost:3000
+INTEGRATION_ENCRYPTION_KEY=your-32-byte-hexadecimal-key # Generate with: openssl rand -hex 32
 ```
 
 Optional OAuth providers (configure at least one for authentication):
@@ -384,7 +388,9 @@ export type SendMessageInput = StepInput & {
 /**
  * Send message logic - separated for clarity and testability
  */
-async function sendMessage(input: SendMessageInput): Promise<SendMessageResult> {
+async function sendMessage(
+  input: SendMessageInput
+): Promise<SendMessageResult> {
   const credentials = input.integrationId
     ? await fetchCredentials(input.integrationId)
     : {};
@@ -788,7 +794,9 @@ import "server-only";
 
 import { type StepInput, withStepLogging } from "@/lib/steps/step-handler";
 
-type MyResult = { success: true; data: string } | { success: false; error: string };
+type MyResult =
+  | { success: true; data: string }
+  | { success: false; error: string };
 
 export type MyInput = StepInput & {
   field1: string;

--- a/README.md
+++ b/README.md
@@ -38,18 +38,24 @@ You can deploy your own version of the workflow builder to Vercel with one click
 
 ### Environment Variables
 
-Create a `.env.local` file with the following:
+Create a `.env.local` file (or rename the existing `.env.example` file) with the following:
 
 ```env
 # Database
 DATABASE_URL=postgresql://user:password@localhost:5432/workflow_builder
 
 # Better Auth
-BETTER_AUTH_SECRET=your-secret-key
+BETTER_AUTH_SECRET=your-secret-key # Generate with: openssl rand -base64 32
 BETTER_AUTH_URL=http://localhost:3000
 
 # AI Gateway (for AI workflow generation)
 AI_GATEWAY_API_KEY=your-openai-api-key
+
+# API URL (for application Route Handlers)
+NEXT_PUBLIC_API_URL=http://localhost:3000
+
+# Credentials Encryption
+INTEGRATION_ENCRYPTION_KEY=your-32-byte-hexadecimal-key # Generate with: openssl rand -hex 32
 ```
 
 ### Installation


### PR DESCRIPTION
This PR introduces the following changes:

- Updated `.gitignore` to allow `.env.example` files.
- Created a `.env.example` with all environment variables referenced throughout the project.
- Updated `README.md` with a snippet including the updated environment variable documentation (`NEXT_PUBLIC_API_URL` and `INTEGRATION_ENCRYPTION_KEY`)
- Updated `CONTRIBUTING.md` with additional available environment variables