### PR TITLE
Replace SDK dependencies with fetch in plugins

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -78,3 +78,8 @@ If any of the above commands fail or show errors:
   - `api.workflow.*` - Workflow CRUD and operations (create, update, delete, deploy, execute, etc.)
 - **No Barrel Files**: Do not create barrel/index files that re-export from other files
 
+## Plugin Guidelines
+- **No SDK Dependencies**: Plugin step files must use `fetch` directly instead of SDK client libraries. Do not add npm package dependencies for API integrations.
+- **No dependencies field**: Do not use the `dependencies` field in plugin `index.ts` files. All API calls should use native `fetch`.
+- **Why**: Using `fetch` instead of SDKs reduces supply chain attack surface. SDKs have transitive dependencies that could be compromised.
+

--- a/app/api/integrations/[integrationId]/test/route.ts
+++ b/app/api/integrations/[integrationId]/test/route.ts
@@ -1,10 +1,6 @@
-import { LinearClient } from "@linear/sdk";
-import FirecrawlApp from "@mendable/firecrawl-js";
-import { WebClient } from "@slack/web-api";
 import { createGateway } from "ai";
 import { NextResponse } from "next/server";
 import postgres from "postgres";
-import { Resend } from "resend";
 import { auth } from "@/lib/auth";
 import { getIntegration } from "@/lib/db/integrations";
 
@@ -104,8 +100,35 @@ async function testLinearConnection(
       };
     }
 
-    const client = new LinearClient({ apiKey });
-    await client.viewer;
+    const response = await fetch("https://api.linear.app/graphql", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: apiKey,
+      },
+      body: JSON.stringify({
+        query: "query { viewer { id } }",
+      }),
+    });
+
+    if (!response.ok) {
+      return {
+        status: "error",
+        message: "Connection failed",
+      };
+    }
+
+    const result = (await response.json()) as {
+      data?: { viewer?: { id: string } };
+      errors?: Array<{ message: string }>;
+    };
+
+    if (result.errors?.length || !result.data?.viewer) {
+      return {
+        status: "error",
+        message: "Connection failed",
+      };
+    }
 
     return {
       status: "success",
@@ -130,13 +153,26 @@ async function testSlackConnection(
       };
     }
 
-    const client = new WebClient(apiKey);
-    const slackAuth = await client.auth.test();
+    const response = await fetch("https://slack.com/api/auth.test", {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${apiKey}`,
+      },
+    });
 
-    if (!slackAuth.ok) {
+    if (!response.ok) {
       return {
         status: "error",
-        message: slackAuth.error || "Connection failed",
+        message: "Connection failed",
+      };
+    }
+
+    const result = (await response.json()) as { ok: boolean; error?: string };
+
+    if (!result.ok) {
+      return {
+        status: "error",
+        message: result.error || "Connection failed",
       };
     }
 
@@ -163,10 +199,14 @@ async function testResendConnection(
       };
     }
 
-    const resend = new Resend(apiKey);
-    const domains = await resend.domains.list();
+    const response = await fetch("https://api.resend.com/domains", {
+      method: "GET",
+      headers: {
+        Authorization: `Bearer ${apiKey}`,
+      },
+    });
 
-    if (!domains.data) {
+    if (!response.ok) {
       return {
         status: "error",
         message: "Connection failed",
@@ -263,12 +303,19 @@ async function testFirecrawlConnection(
       };
     }
 
-    const app = new FirecrawlApp({ apiKey });
-    const result = await app.scrape("https://firecrawl.dev", {
-      formats: ["markdown"],
+    const response = await fetch("https://api.firecrawl.dev/v1/scrape", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${apiKey}`,
+      },
+      body: JSON.stringify({
+        url: "https://example.com",
+        formats: ["markdown"],
+      }),
     });
 
-    if (!result) {
+    if (!response.ok) {
       return {
         status: "error",
         message: "Authentication or scrape failed",

--- a/plugins/firecrawl/index.ts
+++ b/plugins/firecrawl/index.ts
@@ -32,10 +32,6 @@ const firecrawlPlugin: IntegrationPlugin = {
     },
   },
 
-  dependencies: {
-    "@mendable/firecrawl-js": "^4.6.2",
-  },
-
   actions: [
     {
       slug: "scrape",

--- a/plugins/linear/index.ts
+++ b/plugins/linear/index.ts
@@ -42,10 +42,6 @@ const linearPlugin: IntegrationPlugin = {
     },
   },
 
-  dependencies: {
-    "@linear/sdk": "^63.2.0",
-  },
-
   actions: [
     {
       slug: "create-ticket",

--- a/plugins/registry.ts
+++ b/plugins/registry.ts
@@ -149,7 +149,8 @@ export type IntegrationPlugin = {
     >;
   };
 
-  // NPM dependencies required by this plugin (package name -> version)
+  // Avoid using this field. Plugins should use fetch instead of SDK dependencies
+  // to reduce supply chain attack surface. Only use for codegen if absolutely necessary.
   dependencies?: Record<string, string>;
 
   // Actions provided by this integration

--- a/plugins/resend/index.ts
+++ b/plugins/resend/index.ts
@@ -41,10 +41,6 @@ const resendPlugin: IntegrationPlugin = {
     },
   },
 
-  dependencies: {
-    resend: "^6.4.0",
-  },
-
   actions: [
     {
       slug: "send-email",

--- a/plugins/slack/index.ts
+++ b/plugins/slack/index.ts
@@ -32,10 +32,6 @@ const slackPlugin: IntegrationPlugin = {
     },
   },
 
-  dependencies: {
-    "@slack/web-api": "^7.12.0",
-  },
-
   actions: [
     {
       slug: "send-message",

--- a/plugins/slack/test.ts
+++ b/plugins/slack/test.ts
@@ -1,4 +1,9 @@
-import { WebClient } from "@slack/web-api";
+const SLACK_API_URL = "https://slack.com/api";
+
+type SlackAuthTestResponse = {
+  ok: boolean;
+  error?: string;
+};
 
 export async function testSlack(credentials: Record<string, string>) {
   try {
@@ -11,20 +16,30 @@ export async function testSlack(credentials: Record<string, string>) {
       };
     }
 
-    // Test the Slack API by calling auth.test
-    const slack = new WebClient(apiKey);
-    const result = await slack.auth.test();
+    const response = await fetch(`${SLACK_API_URL}/auth.test`, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${apiKey}`,
+      },
+    });
+
+    if (!response.ok) {
+      return {
+        success: false,
+        error: `API validation failed: HTTP ${response.status}`,
+      };
+    }
+
+    const result = (await response.json()) as SlackAuthTestResponse;
 
     if (!result.ok) {
       return {
         success: false,
-        error: "Invalid Slack Bot Token",
+        error: result.error || "Invalid Slack Bot Token",
       };
     }
 
-    return {
-      success: true,
-    };
+    return { success: true };
   } catch (error) {
     return {
       success: false,


### PR DESCRIPTION
Reduces supply chain attack surface by using native `fetch` instead of SDK client libraries for plugin API calls.

**Changes:**

- Resend: Removed `resend` SDK, now uses `https://api.resend.com`
- Linear: Removed `@linear/sdk`, now uses GraphQL at `https://api.linear.app/graphql`
- Firecrawl: Removed `@mendable/firecrawl-js`, now uses `https://api.firecrawl.dev/v1`
- Slack: Removed `@slack/web-api`, now uses `https://slack.com/api`
- Updated integration test route to use fetch for all above
- Removed `dependencies` field from plugin index.ts files
- Added plugin guidelines to AGENTS.md discouraging SDK usage