### PR TITLE
feat(workflow): add schema inference

### DIFF
--- a/components/workflow/config/trigger-config.tsx
+++ b/components/workflow/config/trigger-config.tsx
@@ -1,9 +1,15 @@
 "use client";
 
-import { Clock, Copy, Play, Webhook } from "lucide-react";
+import { Clock, Copy, MoreVertical, Play, Webhook } from "lucide-react";
 import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
 import { CodeEditor } from "@/components/ui/code-editor";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import {
@@ -125,7 +131,28 @@ export function TriggerConfig({
             </p>
           </div>
           <div className="space-y-2">
-            <Label htmlFor="webhookMockRequest">Mock Request (Optional)</Label>
+            <div className="flex items-center justify-between gap-2">
+              <Label htmlFor="webhookMockRequest">
+                Mock Request (Optional)
+              </Label>
+              <DropdownMenu>
+                <DropdownMenuTrigger asChild>
+                  <Button disabled={disabled} size="icon" variant="outline">
+                    <MoreVertical className="h-4 w-4" />
+                  </Button>
+                </DropdownMenuTrigger>
+                <DropdownMenuContent align="end">
+                  <DropdownMenuItem
+                    disabled={disabled || !config?.webhookMockRequest}
+                    onClick={() => {
+                      handleInferSchema(config.webhookMockRequest as string);
+                    }}
+                  >
+                    Infer Schema
+                  </DropdownMenuItem>
+                </DropdownMenuContent>
+              </DropdownMenu>
+            </div>
             <div className="overflow-hidden rounded-md border">
               <CodeEditor
                 defaultLanguage="json"
@@ -144,28 +171,9 @@ export function TriggerConfig({
                 value={(config?.webhookMockRequest as string) || ""}
               />
             </div>
-            <div className="flex items-center justify-between">
-              <p className="text-muted-foreground text-xs">
-                Enter a sample JSON payload to test the webhook trigger.
-              </p>
-              <Button
-                disabled={disabled || !config?.webhookMockRequest}
-                onClick={() => {
-                  const mockRequest = config?.webhookMockRequest as string;
-                  if (mockRequest) {
-                    try {
-                      handleInferSchema(config?.webhookMockRequest as string);
-                    } catch {
-                      toast.error("Failed to infer schema from mock payload");
-                    }
-                  }
-                }}
-                size="sm"
-                variant="outline"
-              >
-                Infer Schema
-              </Button>
-            </div>
+            <p className="text-muted-foreground text-xs">
+              Enter a sample JSON payload to test the webhook trigger.
+            </p>
           </div>
         </>
       )}

--- a/components/workflow/config/trigger-config.tsx
+++ b/components/workflow/config/trigger-config.tsx
@@ -14,6 +14,7 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { TimezoneSelect } from "@/components/ui/timezone-select";
+import { inferSchemaFromJSON } from "../utils/json-parser";
 import { SchemaBuilder, type SchemaField } from "./schema-builder";
 
 type TriggerConfigProps = {
@@ -38,6 +39,12 @@ export function TriggerConfig({
       navigator.clipboard.writeText(webhookUrl);
       toast.success("Webhook URL copied to clipboard");
     }
+  };
+
+  const handleInferSchema = (mockRequest: string) => {
+    const inferredSchema = inferSchemaFromJSON(mockRequest);
+    onUpdateConfig("webhookSchema", JSON.stringify(inferredSchema));
+    toast.success("Schema inferred from mock payload");
   };
 
   return (
@@ -137,9 +144,28 @@ export function TriggerConfig({
                 value={(config?.webhookMockRequest as string) || ""}
               />
             </div>
-            <p className="text-muted-foreground text-xs">
-              Enter a sample JSON payload to test the webhook trigger.
-            </p>
+            <div className="flex items-center justify-between">
+              <p className="text-muted-foreground text-xs">
+                Enter a sample JSON payload to test the webhook trigger.
+              </p>
+              <Button
+                disabled={disabled || !config?.webhookMockRequest}
+                onClick={() => {
+                  const mockRequest = config?.webhookMockRequest as string;
+                  if (mockRequest) {
+                    try {
+                      handleInferSchema(config?.webhookMockRequest as string);
+                    } catch {
+                      toast.error("Failed to infer schema from mock payload");
+                    }
+                  }
+                }}
+                size="sm"
+                variant="outline"
+              >
+                Infer Schema
+              </Button>
+            </div>
           </div>
         </>
       )}

--- a/components/workflow/utils/json-parser.ts
+++ b/components/workflow/utils/json-parser.ts
@@ -42,6 +42,11 @@ const processArray = (arr: unknown[]): ArrayStructure => {
   }
 
   const firstElement = arr[0];
+
+  if (Array.isArray(firstElement)) {
+    return { type: "array", itemType: "object" };
+  }
+
   if (
     typeof firstElement === "object" &&
     firstElement !== null &&
@@ -50,8 +55,11 @@ const processArray = (arr: unknown[]): ArrayStructure => {
     return { type: "array", itemType: extractFields(firstElement) };
   }
 
-  // For primitive arrays, detect the type of the first element
-  return { type: "array", itemType: detectType(firstElement) };
+  const detectedType = detectType(firstElement);
+  if (detectedType === "array") {
+    return { type: "array", itemType: "object" };
+  }
+  return { type: "array", itemType: detectedType };
 };
 
 const extractFields = (obj: unknown): FieldsStructure => {
@@ -98,7 +106,12 @@ const createArrayField = (
   };
 
   if (typeof arrayStructure.itemType === "string") {
-    field.itemType = arrayStructure.itemType as ValidItemType;
+    if (arrayStructure.itemType === "array") {
+      field.itemType = "object";
+      field.fields = [];
+    } else {
+      field.itemType = arrayStructure.itemType as ValidItemType;
+    }
   } else if (typeof arrayStructure.itemType === "object") {
     field.itemType = "object";
     field.fields = convertToSchemaFields(arrayStructure.itemType);

--- a/components/workflow/utils/json-parser.ts
+++ b/components/workflow/utils/json-parser.ts
@@ -1,0 +1,144 @@
+import { nanoid } from "nanoid";
+import type { SchemaField } from "@/components/workflow/config/schema-builder";
+
+type ValidFieldType = SchemaField["type"];
+type ValidItemType = NonNullable<SchemaField["itemType"]>;
+
+type ArrayStructure = {
+  type: "array";
+  itemType: ValidFieldType | FieldsStructure;
+};
+
+type FieldsStructure = {
+  [key: string]: ValidFieldType | FieldsStructure | ArrayStructure;
+};
+
+const detectType = (value: unknown): ValidFieldType => {
+  if (value === null) {
+    return "string";
+  }
+  if (Array.isArray(value)) {
+    return "array";
+  }
+  const t = typeof value;
+  if (t === "object") {
+    return "object";
+  }
+  if (t === "string") {
+    return "string";
+  }
+  if (t === "number") {
+    return "number";
+  }
+  if (t === "boolean") {
+    return "boolean";
+  }
+  return "string";
+};
+
+const processArray = (arr: unknown[]): ArrayStructure => {
+  if (arr.length === 0) {
+    return { type: "array", itemType: "string" };
+  }
+
+  const firstElement = arr[0];
+  if (
+    typeof firstElement === "object" &&
+    firstElement !== null &&
+    !Array.isArray(firstElement)
+  ) {
+    return { type: "array", itemType: extractFields(firstElement) };
+  }
+
+  // For primitive arrays, detect the type of the first element
+  return { type: "array", itemType: detectType(firstElement) };
+};
+
+const extractFields = (obj: unknown): FieldsStructure => {
+  if (obj === null || typeof obj !== "object" || Array.isArray(obj)) {
+    return {};
+  }
+
+  const result: FieldsStructure = {};
+
+  for (const key in obj as Record<string, unknown>) {
+    if (Object.hasOwn(obj, key)) {
+      const value = (obj as Record<string, unknown>)[key];
+      const valueType = detectType(value);
+
+      if (valueType === "object") {
+        result[key] = extractFields(value);
+      } else if (valueType === "array") {
+        result[key] = processArray(value as unknown[]);
+      } else {
+        result[key] = valueType;
+      }
+    }
+  }
+  return result;
+};
+
+const createPrimitiveField = (
+  key: string,
+  type: ValidFieldType
+): SchemaField => ({
+  id: nanoid(),
+  name: key,
+  type,
+});
+
+const createArrayField = (
+  key: string,
+  arrayStructure: ArrayStructure
+): SchemaField => {
+  const field: SchemaField = {
+    id: nanoid(),
+    name: key,
+    type: "array",
+  };
+
+  if (typeof arrayStructure.itemType === "string") {
+    field.itemType = arrayStructure.itemType as ValidItemType;
+  } else if (typeof arrayStructure.itemType === "object") {
+    field.itemType = "object";
+    field.fields = convertToSchemaFields(arrayStructure.itemType);
+  }
+
+  return field;
+};
+
+const createObjectField = (
+  key: string,
+  fieldsStructure: FieldsStructure
+): SchemaField => ({
+  id: nanoid(),
+  name: key,
+  type: "object",
+  fields: convertToSchemaFields(fieldsStructure),
+});
+
+const convertToSchemaFields = (
+  fieldsStructure: FieldsStructure
+): SchemaField[] => {
+  const result: SchemaField[] = [];
+
+  for (const [key, value] of Object.entries(fieldsStructure)) {
+    if (typeof value === "string") {
+      result.push(createPrimitiveField(key, value));
+    } else if (typeof value === "object" && value !== null) {
+      if ("type" in value && value.type === "array") {
+        result.push(createArrayField(key, value as ArrayStructure));
+      } else {
+        result.push(createObjectField(key, value as FieldsStructure));
+      }
+    }
+  }
+
+  return result;
+};
+
+export const inferSchemaFromJSON = (jsonString: string): SchemaField[] => {
+  const parsed = JSON.parse(jsonString);
+  const fieldsStructure = extractFields(parsed);
+  return convertToSchemaFields(fieldsStructure);
+};


### PR DESCRIPTION
## SUMMARY
This PR adds a feature for inferring a response schema based on a mock payload.

Just paste an example payload from your source and select "Infer Schema" and it will automatically add all the values to the Request Schema section.

## CHANGES
+ added `components/workflow/utils/json-parser.ts`
+ modified `trigger-config.tsx` to add infer schema button

<img width="426" height="344" alt="Screenshot 2025-12-01 at 9 15 17 PM" src="https://github.com/user-attachments/assets/7f7b6d8b-c076-4996-8d89-5109e536a2d7" />
