### PR TITLE
feat: add system prompt option to Superagent guard step

### DIFF
--- a/plugins/superagent/index.ts
+++ b/plugins/superagent/index.ts
@@ -57,6 +57,14 @@ const superagentPlugin: IntegrationPlugin = {
           required: true,
           rows: 4,
         },
+        {
+          key: "systemPrompt",
+          label: "System Prompt",
+          type: "template-textarea",
+          placeholder: "Optional custom instructions for the guard...",
+          example: "Be extra strict with code-related inputs",
+          rows: 3,
+        },
       ],
     },
     {

--- a/plugins/superagent/steps/guard.ts
+++ b/plugins/superagent/steps/guard.ts
@@ -16,6 +16,7 @@ type GuardResult = {
 
 export type SuperagentGuardCoreInput = {
   text: string;
+  systemPrompt?: string;
 };
 
 export type SuperagentGuardInput = StepInput &
@@ -45,6 +46,7 @@ async function stepHandler(
       },
       body: JSON.stringify({
         text: input.text,
+        ...(input.systemPrompt && { system_prompt: input.systemPrompt }),
       }),
     });
 


### PR DESCRIPTION
# Description

This PR adds a new `system prompt` field to the Superagent guardrails which enables users to customize guardrails. 