### PR TITLE
fix: prevent duplicate edges between same nodes

### DIFF
--- a/components/workflow/workflow-canvas.tsx
+++ b/components/workflow/workflow-canvas.tsx
@@ -271,6 +271,17 @@ export function WorkflowCanvas() {
 
   const onConnect: OnConnect = useCallback(
     (connection: XYFlowConnection) => {
+      // Check if an edge already exists between these nodes
+      const existingEdge = edges.find(
+        (edge) =>
+          edge.source === connection.source && edge.target === connection.target
+      );
+
+      // Prevent duplicate edges between the same nodes
+      if (existingEdge) {
+        return;
+      }
+
       const newEdge = {
         id: nanoid(),
         ...connection,
@@ -416,17 +427,27 @@ export function WorkflowCanvas() {
 
       // Create connection from the source node to the new node
       const fromSource = connectingHandleType.current === "source";
+      const sourceId = fromSource ? sourceNodeId : newNode.id;
+      const targetId = fromSource ? newNode.id : sourceNodeId;
 
-      const newEdge = {
-        id: nanoid(),
-        source: fromSource ? sourceNodeId : newNode.id,
-        target: fromSource ? newNode.id : sourceNodeId,
-        type: "animated",
-      };
-      setEdges([...edges, newEdge]);
-      setHasUnsavedChanges(true);
-      // Trigger immediate autosave for the new edge
-      triggerAutosave({ immediate: true });
+      // Check if an edge already exists between these nodes
+      const existingEdge = edges.find(
+        (edge) => edge.source === sourceId && edge.target === targetId
+      );
+
+      // Only create edge if it doesn't already exist
+      if (!existingEdge) {
+        const newEdge = {
+          id: nanoid(),
+          source: sourceId,
+          target: targetId,
+          type: "animated",
+        };
+        setEdges([...edges, newEdge]);
+        setHasUnsavedChanges(true);
+        // Trigger immediate autosave for the new edge
+        triggerAutosave({ immediate: true });
+      }
 
       // Set flag to prevent immediate deselection
       justCreatedNodeFromConnection.current = true;


### PR DESCRIPTION
## Description

Fixes an issue where users could create multiple edges between the same two nodes, causing duplicate connections in the workflow data.

## Problem

Users could drag from a node handle multiple times to create duplicate edges between the same source and target nodes. This created redundant data and visual clutter in the workflow canvas.

Example of the issue:
```json
"edges": [
  {"id": "edge1", "source": "nodeA", "target": "nodeB"},
  {"id": "edge2", "source": "nodeA", "target": "nodeB"},  // Duplicate
  {"id": "edge3", "source": "nodeA", "target": "nodeB"}   // Duplicate
]
```
## Solution

Added duplicate edge prevention in the onConnect and handleConnectionToNewNode functions in workflow-canvas.tsx:

Check for existing edges between the same source and target before creating new ones
Early return if a duplicate edge already exists
Maintains existing UX while preventing data integrity issues