### PR TITLE
Fix: Export only required env vars in workflow downloads

### DIFF
--- a/plugins/index.ts
+++ b/plugins/index.ts
@@ -49,6 +49,7 @@ export {
   getAllDependencies,
   getAllEnvVars,
   getAllIntegrations,
+  getEnvVarsForActions,
   getCredentialMapping,
   getDependenciesForActions,
   getIntegration,

--- a/plugins/registry.ts
+++ b/plugins/registry.ts
@@ -434,6 +434,34 @@ export function getDependenciesForActions(
 }
 
 /**
+ * Get environment variables for specific action IDs
+ */
+export function getEnvVarsForActions(
+  actionIds: string[]
+): Array<{ name: string; description: string }> {
+  const envVars: Array<{ name: string; description: string }> = [];
+  const integrations = new Set<IntegrationType>();
+
+  // Find which integrations are used
+  for (const actionId of actionIds) {
+    const action = findActionById(actionId);
+    if (action) {
+      integrations.add(action.integration);
+    }
+  }
+
+  // Get env vars for those integrations only
+  for (const integrationType of integrations) {
+    const plugin = integrationRegistry.get(integrationType);
+    if (plugin) {
+      envVars.push(...getPluginEnvVars(plugin));
+    }
+  }
+
+  return envVars;
+}
+
+/**
  * Get environment variables for a single plugin (from formFields)
  */
 export function getPluginEnvVars(


### PR DESCRIPTION
When exporting a workflow as code, the .env.example file now includes only the environment variables for integrations actually used in the workflow, instead of all registered plugins. 

- Updated `generateEnvExample` to accept workflow nodes and extract action IDs.
- Replaced `getAllEnvVars` with `getEnvVarsForActions` to fetch environment variables specific to used integrations.
- Added `getEnvVarsForActions` function to retrieve environment variables based on action IDs from the plugin registry.

Fixes #171 