### PR TITLE
fix: fix local dev could not reolve codegen-registry.ts

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "license": "Apache-2.0",
+  "type": "module",
   "description": "A template for building your own AI-driven workflow automation platform",
   "scripts": {
     "dev": "pnpm discover-plugins && next dev",


### PR DESCRIPTION
pnpm discover-plugins generates empty registries on Linux/local dev due to tsconfig path alias not resolving in CJS dynamic imports

Root cause summary:
- scripts/ has no "type": "module", so tsx runs discover-plugins.ts in CJS modeIn CJS mode, runtime await import("@/plugins/registry") bypasses tx's path alias transform
- This creates a separate module instance from the one plugins register into via ../registryResult: getAllIntegrations() returns [], all generated files have 0 entries, and lib/codegen-registry.ts is never written  breaking pnpm dev with Could not resolve "../../../lib/codegen-registry" #126 