### PR TITLE
docs: update Workflow SDK branding

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # AI Workflow Builder Template
 
-A template for building your own AI-driven workflow automation platform. Built on top of Workflow DevKit, this template provides a complete visual workflow builder with real integrations and code generation capabilities.
+A template for building your own AI-driven workflow automation platform. Built on top of Workflow SDK, this template provides a complete visual workflow builder with real integrations and code generation capabilities.
 
 ![AI Workflow Builder Screenshot](screenshot.png)
 
@@ -19,7 +19,7 @@ You can deploy your own version of the workflow builder to Vercel with one click
 ## What's Included
 
 - **Visual Workflow Builder** - Drag-and-drop interface powered by React Flow
-- **Workflow DevKit Integration** - Built on top of Workflow DevKit for powerful execution capabilities
+- **Workflow SDK Integration** - Built on top of Workflow SDK for powerful execution capabilities
 - **Real Integrations** - Connect to Resend (emails), Linear (tickets), Slack, PostgreSQL, and external APIs
 - **Code Generation** - Convert workflows to executable TypeScript with `"use workflow"` directive
 - **Execution Tracking** - Monitor workflow runs with detailed logs
@@ -273,7 +273,7 @@ const searchResult = await firecrawlSearchStep({
 ## Tech Stack
 
 - **Framework**: Next.js 16 with React 19
-- **Workflow Engine**: Workflow DevKit
+- **Workflow Engine**: Workflow SDK
 - **UI**: shadcn/ui with Tailwind CSS
 - **State Management**: Jotai
 - **Database**: PostgreSQL with Drizzle ORM
@@ -284,9 +284,9 @@ const searchResult = await firecrawlSearchStep({
 - **Type Checking**: TypeScript
 - **Code Quality**: Ultracite (formatter + linter)
 
-## About Workflow DevKit
+## About Workflow SDK
 
-This template is built on top of Workflow DevKit, a powerful workflow execution engine that enables:
+This template is built on top of Workflow SDK, a powerful workflow execution engine that enables:
 
 - Native TypeScript workflow definitions with `"use workflow"` directive
 - Type-safe workflow execution
@@ -294,7 +294,7 @@ This template is built on top of Workflow DevKit, a powerful workflow execution 
 - Built-in logging and error handling
 - Serverless deployment support
 
-Learn more about Workflow DevKit at [useworkflow.dev](https://useworkflow.dev)
+Learn more about Workflow SDK at [workflow-sdk.dev](https://workflow-sdk.dev/)
 
 ## License
 

--- a/app/api/workflows/[workflowId]/download/route.ts
+++ b/app/api/workflows/[workflowId]/download/route.ts
@@ -324,7 +324,7 @@ Deploy your workflow to Vercel:
 vercel deploy
 \`\`\`
 
-For more information, visit the [Workflow documentation](https://workflow.is).
+For more information, visit the [Workflow SDK documentation](https://workflow-sdk.dev/docs).
 `;
 
     // Add .env.example file (dynamically generated from plugin registry)

--- a/components/workflow/nodes/add-node.tsx
+++ b/components/workflow/nodes/add-node.tsx
@@ -19,11 +19,11 @@ export function AddNode({ data }: NodeProps & { data?: AddNodeData }) {
           Powered by{" "}
           <a
             className="underline underline-offset-2 transition duration-200 ease-out hover:text-foreground"
-            href="https://useworkflow.dev/"
+            href="https://workflow-sdk.dev/"
             rel="noopener noreferrer"
             target="_blank"
           >
-            Workflow
+            Workflow SDK
           </a>
           ,{" "}
           <a


### PR DESCRIPTION
## Summary
- replace active Workflow DevKit branding with Workflow SDK in the README and workflow builder UI
- update product and generated documentation links to canonical workflow-sdk.dev URLs

## Test plan
- [x] `pnpm discover-plugins`
- [x] `pnpm type-check`
- [x] `pnpm dlx @biomejs/biome@2.3.4 check --write --no-errors-on-unmatched README.md \"app/api/workflows/[workflowId]/download/route.ts\" \"components/workflow/nodes/add-node.tsx\"`
- [x] scan active source for retired names and domains
- [ ] `pnpm fix` (the repository script resolves incompatible latest Ultracite/Biome tooling)

Made with [Cursor](https://cursor.com)